### PR TITLE
[Feature] Added aggregations without type dimension

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -15,7 +15,7 @@ type Transaction @entity(timeseries: true) {
   createdAtBlock: BigInt!
 }
 
-type TransactionStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
+type TransactionTypeStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
   id: Int8!
   timestamp: Timestamp!
   type: String!
@@ -25,7 +25,7 @@ type TransactionStat @aggregation(intervals: ["hour", "day"], source: "Transacti
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
 }
 
-type TransactionAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
+type TransactionTypeAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
   id: Int8!
   timestamp: Timestamp!
   type: String!
@@ -36,7 +36,7 @@ type TransactionAppStat @aggregation(intervals: ["hour", "day"], source: "Transa
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
 }
 
-type TransactionUserStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
+type TransactionTypeUserStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
   id: Int8!
   timestamp: Timestamp!
   type: String!
@@ -47,10 +47,41 @@ type TransactionUserStat @aggregation(intervals: ["hour", "day"], source: "Trans
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
 }
 
-type TransactionUserAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
+type TransactionTypeUserAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
   id: Int8!
   timestamp: Timestamp!
   type: String!
+  userId: String!
+  appId: String!
+  transactionCount: Int8! @aggregate(fn: "count")
+  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
+  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
+  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+}
+
+type TransactionAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
+  id: Int8!
+  timestamp: Timestamp!
+  appId: String!
+  transactionCount: Int8! @aggregate(fn: "count")
+  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
+  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
+  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+}
+
+type TransactionUserStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
+  id: Int8!
+  timestamp: Timestamp!
+  userId: String!
+  transactionCount: Int8! @aggregate(fn: "count")
+  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
+  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
+  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+}
+
+type TransactionUserAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
+  id: Int8!
+  timestamp: Timestamp!
   userId: String!
   appId: String!
   transactionCount: Int8! @aggregate(fn: "count")

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -28,6 +28,7 @@ dataSources:
       eventHandlers:
         - event: Created(address,address,string)
           handler: handleCreated
+          receipt: true
       file: ./src/AppFactory.ts
 templates:
   - name: ERC721FactoryFacet
@@ -48,6 +49,7 @@ templates:
       eventHandlers:
         - event: Created(address,address,string,string,address,uint16,bytes32)
           handler: handleCreated
+          receipt: true
       file: ./src/facet/ERC721Factory.ts
   - name: ERC721Base
     kind: ethereum/contract
@@ -67,10 +69,13 @@ templates:
       eventHandlers:
         - event: Minted(address,string)
           handler: handleMinted
+          receipt: true
         - event: BatchMinted(address,uint256,string)
           handler: handleBatchMinted
+          receipt: true
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
+          receipt: true
       file: ./src/ERC721Base.ts
   - name: ERC721LazyMint
     kind: ethereum/contract
@@ -90,12 +95,16 @@ templates:
       eventHandlers:
         - event: Minted(address,string)
           handler: handleMinted
+          receipt: true
         - event: BatchMinted(address,uint256,string)
           handler: handleBatchMinted
+          receipt: true
         - event: TokensLazyMinted(indexed uint256,uint256,string,bytes)
           handler: handleLazyMint
+          receipt: true
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
+          receipt: true
       file: ./src/ERC721LazyMint.ts
   - name: ERC721Badge
     kind: ethereum/contract
@@ -115,14 +124,19 @@ templates:
       eventHandlers:
         - event: Minted(address,string)
           handler: handleMinted
+          receipt: true
         - event: BatchMinted(address,uint256,string)
           handler: handleBatchMinted
+          receipt: true
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
+          receipt: true
         - event: UpdatedBaseURI(string)
           handler: handleUpdatedBaseURI
+          receipt: true
         - event: BatchMetadataUpdate(uint256,uint256)
           handler: handleBatchMetadataUpdate
+          receipt: true
       file: ./src/ERC721Badge.ts
   - name: ERC20FactoryFacet
     kind: ethereum/contract
@@ -142,6 +156,7 @@ templates:
       eventHandlers:
         - event: Created(address,address,string,string,uint8,uint256,bytes32)
           handler: handleCreated
+          receipt: true
       file: ./src/facet/ERC20Factory.ts
   - name: ERC20Base
     kind: ethereum/contract
@@ -161,8 +176,10 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+          receipt: true
         - event: ContractURIUpdated(string,string)
           handler: handleContractURIUpdated
+          receipt: true
       file: ./src/ERC20Base.ts
   - name: RewardsFacet
     kind: ethereum/contract
@@ -184,10 +201,14 @@ templates:
       eventHandlers:
         - event: TokenMinted(address,address,uint256,bytes32,bytes32,string)
           handler: handleTokenMinted
+          receipt: true
         - event: TokenTransferred(address,address,uint256,bytes32,bytes32,string)
           handler: handleTokenTransferred
+          receipt: true
         - event: BadgeMinted(address,uint256,address,bytes32,bytes32,string)
           handler: handleBadgeMinted
+          receipt: true
         - event: BadgeTransferred(address,address,uint256,bytes32,bytes32,string)
           handler: handleBadgeTransferred
+          receipt: true
       file: ./src/facet/RewardsFacet.ts


### PR DESCRIPTION
## Summary

Added aggregations over transactions without `type` dimension. Renamed aggregations to more appropriate names.

## Description

Aggregation have been renamed to use the following pattern: **TransactionDimension1Dimension2...Stat**.

Meaning if we want aggregation by `Type` , `User` and `App` we should query aggregation `TransactionTypeUserAppStat`

New aggregations where added that do not have the `type` dimension. This change facilitates calculations given that we do not have to loop over all different types to get totals.

## Related Issue/Bounty

OF-283 - Difficult to get transaction totals

## Type of Change

Please check the boxes that apply to your pull request:

- [X] Breaking change (fix or feature that would cause existing functionality to change)

All previous queries need to be updated because aggregations have changed names.

