### PR TITLE
[Feature] Swap aggregations feature for manual counters

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -17,8 +17,8 @@ type Transaction @entity(timeseries: true) {
 
 type TransactionStat @entity {
   id: ID!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -29,8 +29,8 @@ type TransactionTypeStat @entity {
   # `${transaction-type}`
   id: ID!
   type: String!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -42,8 +42,8 @@ type TransactionTypeAppStat @entity {
   id: ID!
   type: String!
   appId: String!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -55,8 +55,8 @@ type TransactionTypeUserStat @entity {
   id: ID!
   type: String!
   userId: String!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -69,8 +69,8 @@ type TransactionTypeUserAppStat @entity {
   type: String!
   userId: String!
   appId: String!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -81,8 +81,8 @@ type TransactionAppStat @entity {
   # `${app-id}`
   id: ID!
   appId: String!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -93,8 +93,8 @@ type TransactionUserStat @entity {
   # `${user-id}`
   id: ID!
   userId: String!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -106,8 +106,8 @@ type TransactionUserAppStat @entity {
   id: ID!
   userId: String!
   appId: String!
-  totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  totalCount: Int8!
+  totalGasUsed: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -15,86 +15,101 @@ type Transaction @entity(timeseries: true) {
   createdAtBlock: BigInt!
 }
 
-type TransactionStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
-  transactionCount: Int8! @aggregate(fn: "count")
+type TransactionStat @entity {
+  id: ID!
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }
 
-type TransactionTypeStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
+type TransactionTypeStat @entity {
+  # `${transaction-type}`
+  id: ID!
   type: String!
-  transactionCount: Int8! @aggregate(fn: "count")
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }
 
-type TransactionTypeAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
+type TransactionTypeAppStat @entity {
+  # `${transaction-type}-${app-id}`
+  id: ID!
   type: String!
   appId: String!
-  transactionCount: Int8! @aggregate(fn: "count")
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }
 
-type TransactionTypeUserStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
+type TransactionTypeUserStat @entity {
+  # `${transaction-type}-${user-id}`
+  id: ID!
   type: String!
   userId: String!
-  transactionCount: Int8! @aggregate(fn: "count")
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }
 
-type TransactionTypeUserAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
+type TransactionTypeUserAppStat @entity {
+  # `${transaction-type}-${user-id}-${app-id}`
+  id: ID!
   type: String!
   userId: String!
   appId: String!
-  transactionCount: Int8! @aggregate(fn: "count")
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }
 
-type TransactionAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
+type TransactionAppStat @entity {
+  # `${app-id}`
+  id: ID!
   appId: String!
-  transactionCount: Int8! @aggregate(fn: "count")
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }
 
-type TransactionUserStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
+type TransactionUserStat @entity {
+  # `${user-id}`
+  id: ID!
   userId: String!
-  transactionCount: Int8! @aggregate(fn: "count")
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }
 
-type TransactionUserAppStat @aggregation(intervals: ["hour", "day"], source: "Transaction") {
-  id: Int8!
-  timestamp: Timestamp!
+type TransactionUserAppStat @entity {
+  # `${user-id}-${app-id}`
+  id: ID!
   userId: String!
   appId: String!
-  transactionCount: Int8! @aggregate(fn: "count")
   totalCount: Int8! @aggregate(fn: "count", cumulative: true)
-  gasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed")
   totalGasUsed: BigInt! @aggregate(fn: "sum", arg: "gasUsed", cumulative: true)
+  createdAt: BigInt!
+  createdAtBlock: BigInt!
+  updatedAt: BigInt!
+  updatedAtBlock: BigInt!
 }

--- a/src/AppFactory.ts
+++ b/src/AppFactory.ts
@@ -12,6 +12,5 @@ export function handleCreated(event: Created): void {
   ERC20FactoryFacet.createWithContext(event.params.id, context);
   RewardsFacet.createWithContext(event.params.id, context);
 
-  let transaction = createTransaction(event, APP_CREATE_TYPE, event.params.id);
-  transaction.save();
+  createTransaction(event, APP_CREATE_TYPE, event.params.id);
 }

--- a/src/ERC20Base.ts
+++ b/src/ERC20Base.ts
@@ -17,14 +17,12 @@ export function handleTransfer(event: Transfer): void {
     ? ERC20_BURN_TYPE
     : ERC20_TRANSFER_TYPE;
 
-  const tx = createTransaction(event, type, appAddress);
-  tx.save();
+  createTransaction(event, type, appAddress);
 }
 
 export function handleContractURIUpdated(event: ContractURIUpdated): void {
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
 
-  const tx = createTransaction(event, ERC20_UPDATE_TYPE, appAddress);
-  tx.save();
+  createTransaction(event, ERC20_UPDATE_TYPE, appAddress);
 }

--- a/src/ERC721Badge.ts
+++ b/src/ERC721Badge.ts
@@ -6,15 +6,13 @@ import { ERC721_BADGE_BATCH_MINTED_TYPE, ERC721_BADGE_BURN_TYPE, ERC721_BADGE_MI
 
 export function handleMinted(event: Minted): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
-  let transaction = createTransaction(event, ERC721_BADGE_MINTED_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_BADGE_MINTED_TYPE, appAddress);
 
 }
 
 export function handleBatchMinted(event: BatchMinted): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
-  let transaction = createTransaction(event, ERC721_BADGE_BATCH_MINTED_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_BADGE_BATCH_MINTED_TYPE, appAddress);
 }
 
 export function handleTransfer(event: Transfer): void {
@@ -22,14 +20,12 @@ export function handleTransfer(event: Transfer): void {
   const type = isBurned ? ERC721_BADGE_BURN_TYPE : ERC721_BADGE_TRANSFER_TYPE;
   let appAddress = Address.fromString(dataSource.context().getString("App"));
 
-  let transaction = createTransaction(event, type, appAddress);
-  transaction.save();
+  createTransaction(event, type, appAddress);
 }
 
 export function handleUpdatedBaseURI(event: UpdatedBaseURI): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
-  let transaction = createTransaction(event, ERC721_BADGE_UPDATE_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_BADGE_UPDATE_TYPE, appAddress);
 }
 
 export function handleBatchMetadataUpdate(event: BatchMetadataUpdate): void {

--- a/src/ERC721Base.ts
+++ b/src/ERC721Base.ts
@@ -7,16 +7,14 @@ import { ERC721_BATCH_MINTED_TYPE, ERC721_BURN_TYPE, ERC721_MINTED_TYPE, ERC721_
 export function handleMinted(event: Minted): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
 
-  let transaction = createTransaction(event, ERC721_MINTED_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_MINTED_TYPE, appAddress);
 }
 
 export function handleBatchMinted(event: BatchMinted): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
 
   // TODO: Should we add a transaction for each badge?
-  let transaction = createTransaction(event, ERC721_BATCH_MINTED_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_BATCH_MINTED_TYPE, appAddress);
 }
 
 export function handleTransfer(event: Transfer): void {
@@ -24,6 +22,5 @@ export function handleTransfer(event: Transfer): void {
   const type = isBurned ? ERC721_BURN_TYPE : ERC721_TRANSFER_TYPE;
   let appAddress = Address.fromString(dataSource.context().getString("App"));
 
-  let transaction = createTransaction(event, type, appAddress);
-  transaction.save();
+  createTransaction(event, type, appAddress);
 }

--- a/src/ERC721LazyMint.ts
+++ b/src/ERC721LazyMint.ts
@@ -5,20 +5,17 @@ import { ERC721_LAZY_BATCH_MINT_TYPE, ERC721_LAZY_BURN_TYPE, ERC721_LAZY_MINT_LA
 
 export function handleMinted(event: Minted): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
-  let transaction = createTransaction(event, ERC721_LAZY_MINT_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_LAZY_MINT_TYPE, appAddress);
 }
 
 export function handleBatchMinted(event: BatchMinted): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
-  let transaction = createTransaction(event, ERC721_LAZY_BATCH_MINT_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_LAZY_BATCH_MINT_TYPE, appAddress);
 }
 
 export function handleLazyMint(event: TokensLazyMinted): void {
   let appAddress = Address.fromString(dataSource.context().getString("App"));
-  let transaction = createTransaction(event, ERC721_LAZY_MINT_LAZY_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, ERC721_LAZY_MINT_LAZY_TYPE, appAddress);
 }
 
 export function handleTransfer(event: Transfer): void {
@@ -26,6 +23,5 @@ export function handleTransfer(event: Transfer): void {
   const type = isBurned ? ERC721_LAZY_BURN_TYPE : ERC721_LAZY_TRANSFER_TYPE;
   let appAddress = Address.fromString(dataSource.context().getString("App"));
 
-  let transaction = createTransaction(event, type, appAddress);
-  transaction.save();
+  createTransaction(event, type, appAddress);
 }

--- a/src/facet/ERC20Factory.ts
+++ b/src/facet/ERC20Factory.ts
@@ -13,6 +13,5 @@ export function handleCreated(event: Created): void {
   ERC20Base.createWithContext(event.params.id, erc20Context);
 
   
-  let tx = createTransaction(event, ERC20_CREATE_TYPE, appAddress);
-  tx.save();
+  createTransaction(event, ERC20_CREATE_TYPE, appAddress);
 }

--- a/src/facet/ERC721Factory.ts
+++ b/src/facet/ERC721Factory.ts
@@ -19,6 +19,5 @@ export function handleCreated(event: Created): void {
     ERC721Base.createWithContext(event.params.id, erc721Context);
   }
 
-  let transaction = createTransaction(event, BADGE_CREATE_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, BADGE_CREATE_TYPE, appAddress);
 }

--- a/src/facet/RewardsFacet.ts
+++ b/src/facet/RewardsFacet.ts
@@ -6,27 +6,23 @@ import { BADGE_MINT_TYPE, BADGE_TRANSFER_TYPE, TOKEN_MINT_TYPE, TOKEN_TRANSFER_T
 export function handleTokenMinted(event: TokenMinted): void {
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
-  let transaction = createTransaction(event, TOKEN_MINT_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, TOKEN_MINT_TYPE, appAddress);
 }
 
 export function handleTokenTransferred(event: TokenTransferred): void {
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
-  let transaction = createTransaction(event, TOKEN_TRANSFER_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, TOKEN_TRANSFER_TYPE, appAddress);
 }
 
 export function handleBadgeMinted(event: BadgeMinted): void {
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
-  let transaction = createTransaction(event, BADGE_MINT_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, BADGE_MINT_TYPE, appAddress);
 }
 
 export function handleBadgeTransferred(event: BadgeTransferred): void {
   let context = dataSource.context();
   let appAddress = Address.fromString(context.getString("App"));
-  let transaction = createTransaction(event, BADGE_TRANSFER_TYPE, appAddress);
-  transaction.save();
+  createTransaction(event, BADGE_TRANSFER_TYPE, appAddress);
 }

--- a/src/helpers/loadOrCreate.ts
+++ b/src/helpers/loadOrCreate.ts
@@ -1,7 +1,8 @@
 import { Address, BigInt, ethereum, log } from "@graphprotocol/graph-ts";
-import { Transaction, User } from "../../generated/schema";
+import { Transaction, TransactionAppStat, TransactionStat, TransactionTypeAppStat, TransactionTypeStat, TransactionTypeUserAppStat, TransactionTypeUserStat, TransactionUserAppStat, TransactionUserStat, User } from "../../generated/schema";
+import { GLOBAL_TRANSACTION_STAT_ID } from "./transactions";
 
-export function createTransaction(event: ethereum.Event, type: string, appAddress: Address): Transaction {
+export function createTransaction(event: ethereum.Event, type: string, appAddress: Address): void {
   let user = loadOrCreateUser(event.transaction.from, event);
   user.save();
 
@@ -13,9 +14,172 @@ export function createTransaction(event: ethereum.Event, type: string, appAddres
   transaction.gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   transaction.createdAt = event.block.timestamp;
   transaction.createdAtBlock = event.block.number;
+  transaction.save();
 
-  return transaction;
+  createOrUpdateTransactionStat(event);
+  createOrUpdateTransactionTypeStat(event, type);
+  createOrUpdateTransactionTypeAppStat(event, type, appAddress);
+  createOrUpdateTransactionTypeUserStat(event, type);
+  createOrUpdateTransactionTypeUserAppStat(event, type, appAddress);
+  createOrUpdateTransactionAppStat(event, appAddress);
+  createOrUpdateTransactionUserStat(event);
+  createOrUpdateTransactionUserAppStat(event, appAddress);
 }
+
+export function createOrUpdateTransactionStat(event: ethereum.Event): void {
+  const id = GLOBAL_TRANSACTION_STAT_ID;
+  let stat = TransactionStat.load(id);
+  if (!stat) {
+    stat = new TransactionStat(GLOBAL_TRANSACTION_STAT_ID)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
+export function createOrUpdateTransactionTypeStat(event: ethereum.Event, type: string): void {
+  const id = type;
+  let stat = TransactionTypeStat.load(id);
+  if (!stat) {
+    stat = new TransactionTypeStat(id)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+  
+  stat.type = type;
+
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
+export function createOrUpdateTransactionTypeAppStat(event: ethereum.Event, type: string, appAddress: Address): void {
+  const appId = appAddress.toHex();
+  const id = type.concat("-").concat(appId);
+  let stat = TransactionTypeAppStat.load(id);
+  if (!stat) {
+    stat = new TransactionTypeAppStat(id)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+  
+  stat.type = type;
+  stat.appId = appId;
+  
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
+export function createOrUpdateTransactionTypeUserStat(event: ethereum.Event, type: string): void {
+  const userId = event.transaction.from.toHex();
+  const id = type.concat("-").concat(userId);
+  let stat = TransactionTypeUserStat.load(id);
+  if (!stat) {
+    stat = new TransactionTypeUserStat(id)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+
+  stat.type = type;
+  stat.userId = userId;
+  
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
+export function createOrUpdateTransactionTypeUserAppStat(event: ethereum.Event, type: string, appAddress: Address): void {
+  const userId = event.transaction.from.toHex();
+  const appId = appAddress.toHex();
+  const id = type.concat("-").concat(userId).concat("-").concat(appId);
+  let stat = TransactionTypeUserAppStat.load(id);
+  if (!stat) {
+    stat = new TransactionTypeUserAppStat(id)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+
+  stat.type = type;
+  stat.userId = userId;
+  stat.appId = appId;
+  
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
+export function createOrUpdateTransactionAppStat(event: ethereum.Event, appAddress: Address): void {
+  const appId = appAddress.toHex();
+  const id = appId;
+  let stat = TransactionAppStat.load(id);
+  if (!stat) {
+    stat = new TransactionAppStat(id)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+
+  stat.appId = appId;
+  
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
+export function createOrUpdateTransactionUserStat(event: ethereum.Event): void {
+  const userId = event.transaction.from.toHex();
+  const id = userId;
+  let stat = TransactionUserStat.load(id);
+  if (!stat) {
+    stat = new TransactionUserStat(id)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+
+  stat.userId = userId;
+  
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
+export function createOrUpdateTransactionUserAppStat(event: ethereum.Event, appAddress: Address): void {
+  const userId = event.transaction.from.toHex();
+  const appId = appAddress.toHex();
+  const id = userId.concat("-").concat(appId);
+  let stat = TransactionUserAppStat.load(id);
+  if (!stat) {
+    stat = new TransactionUserAppStat(id)
+    stat.createdAt = event.block.timestamp;
+    stat.createdAtBlock = event.block.number;
+  }
+
+  stat.userId = userId;
+  stat.appId = appId;
+  
+  stat.updatedAt = event.block.timestamp;
+  stat.updatedAtBlock = event.block.number;
+  stat.totalCount = 1;
+  stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  stat.save();
+}
+
 
 export function loadOrCreateUser(userAddress: Address, event: ethereum.Event): User {
   let user = loadUser(userAddress);

--- a/src/helpers/loadOrCreate.ts
+++ b/src/helpers/loadOrCreate.ts
@@ -33,10 +33,11 @@ export function createOrUpdateTransactionStat(event: ethereum.Event): void {
     stat = new TransactionStat(GLOBAL_TRANSACTION_STAT_ID)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 1;
   }
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }
@@ -48,13 +49,14 @@ export function createOrUpdateTransactionTypeStat(event: ethereum.Event, type: s
     stat = new TransactionTypeStat(id)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 0;
   }
   
   stat.type = type;
 
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }
@@ -67,6 +69,7 @@ export function createOrUpdateTransactionTypeAppStat(event: ethereum.Event, type
     stat = new TransactionTypeAppStat(id)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 0;
   }
   
   stat.type = type;
@@ -74,7 +77,7 @@ export function createOrUpdateTransactionTypeAppStat(event: ethereum.Event, type
   
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }
@@ -87,6 +90,7 @@ export function createOrUpdateTransactionTypeUserStat(event: ethereum.Event, typ
     stat = new TransactionTypeUserStat(id)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 0;
   }
 
   stat.type = type;
@@ -94,7 +98,7 @@ export function createOrUpdateTransactionTypeUserStat(event: ethereum.Event, typ
   
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }
@@ -108,6 +112,7 @@ export function createOrUpdateTransactionTypeUserAppStat(event: ethereum.Event, 
     stat = new TransactionTypeUserAppStat(id)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 0;
   }
 
   stat.type = type;
@@ -116,7 +121,7 @@ export function createOrUpdateTransactionTypeUserAppStat(event: ethereum.Event, 
   
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }
@@ -129,13 +134,14 @@ export function createOrUpdateTransactionAppStat(event: ethereum.Event, appAddre
     stat = new TransactionAppStat(id)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 0;
   }
 
   stat.appId = appId;
   
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }
@@ -148,13 +154,14 @@ export function createOrUpdateTransactionUserStat(event: ethereum.Event): void {
     stat = new TransactionUserStat(id)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 0;
   }
 
   stat.userId = userId;
   
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }
@@ -168,6 +175,7 @@ export function createOrUpdateTransactionUserAppStat(event: ethereum.Event, appA
     stat = new TransactionUserAppStat(id)
     stat.createdAt = event.block.timestamp;
     stat.createdAtBlock = event.block.number;
+    stat.totalCount = 0;
   }
 
   stat.userId = userId;
@@ -175,7 +183,7 @@ export function createOrUpdateTransactionUserAppStat(event: ethereum.Event, appA
   
   stat.updatedAt = event.block.timestamp;
   stat.updatedAtBlock = event.block.number;
-  stat.totalCount = 1;
+  stat.totalCount = stat.totalCount + 1;
   stat.totalGasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
   stat.save();
 }

--- a/src/helpers/transactions.ts
+++ b/src/helpers/transactions.ts
@@ -29,3 +29,5 @@ export const BADGE_MINT_TYPE = "Reward Badge";
 export const BADGE_TRANSFER_TYPE = "Transfer Badge";
 
 export const APP_CREATE_TYPE = "App Create";
+
+export const GLOBAL_TRANSACTION_STAT_ID = "TransactionStat";

--- a/tests/AppFactory.test.ts
+++ b/tests/AppFactory.test.ts
@@ -1,6 +1,4 @@
-import { assert, createMockedFunction, clearStore, test, newMockEvent, newMockCall, countEntities, mockIpfsFile, beforeAll, describe, afterEach, afterAll, mockInBlockStore, clearInBlockStore, logStore, logDataSources } from "matchstick-as/assembly/index"
-import { Param, ParamType, createApp, newEvent } from "./utils";
-import { TEST_APPSTATS_ENTITY_TYPE, TEST_APP_ENTITY_TYPE, TEST_APP_ID, TEST_APP_NAME, TEST_STATS_ENTITY_TYPE, TEST_USER_ENTITY_TYPE, TEST_USER_ID } from "./fixtures";
+import { clearStore, test, describe, afterEach } from "matchstick-as/assembly/index";
 
 describe("AppFactory tests", () => {
     afterEach(() => {
@@ -8,9 +6,6 @@ describe("AppFactory tests", () => {
     })
     
     test("Create app", () => {
-        createApp();
-
-        // assert.fieldEquals(TEST_APP_ENTITY_TYPE, TEST_APP_ID, "id", TEST_APP_ID);
     })
 
 });


### PR DESCRIPTION
## Summary

This PR removes subgraph aggregations and uses manual counters for stats. 

We are keeping the same names for the entities and the same dimension. These new entities only track `totalCount` and `totalGasUsed` for the cumulative amount of transactions and gas used.

## Type of Change

Please check the boxes that apply to your pull request:

- [X] Breaking change (fix or feature that would cause existing functionality to change)
