### PR TITLE
[Feature] Added totalGasCosts to Stats and gasPrice to Transaction

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -11,6 +11,7 @@ type Transaction @entity(immutable: true) {
   userId: String!
   appId: String!
   gasUsed: BigInt!
+  gasPrice: BigInt!
   events: [Event!] @derivedFrom(field: "transaction")
   createdAt: BigInt!
   createdAtBlock: BigInt!
@@ -20,6 +21,7 @@ type TransactionStat @entity {
   id: ID!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -32,6 +34,7 @@ type TransactionTypeStat @entity {
   transactionType: String!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -45,6 +48,7 @@ type TransactionTypeAppStat @entity {
   appId: String!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -58,6 +62,7 @@ type TransactionTypeUserStat @entity {
   userId: String!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -72,6 +77,7 @@ type TransactionTypeUserAppStat @entity {
   appId: String!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -84,6 +90,7 @@ type TransactionAppStat @entity {
   appId: String!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -96,6 +103,7 @@ type TransactionUserStat @entity {
   userId: String!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!
@@ -109,6 +117,7 @@ type TransactionUserAppStat @entity {
   appId: String!
   totalCount: Int8!
   totalGasUsed: BigInt!
+  totalGasCost: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   updatedAt: BigInt!

--- a/src/helpers/createOrUpdateTransaction.ts
+++ b/src/helpers/createOrUpdateTransaction.ts
@@ -11,11 +11,14 @@ export function createOrUpdateTransactionStat(event: ethereum.Event): void {
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }
 
@@ -28,14 +31,16 @@ export function createOrUpdateTransactionTypeStat(event: ethereum.Event, transac
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
-
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.transactionType = transactionType;
 
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }
 
@@ -49,15 +54,17 @@ export function createOrUpdateTransactionTypeAppStat(event: ethereum.Event, tran
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
-
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.transactionType = transactionType;
     stat.appId = appId;
 
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }
 
@@ -71,15 +78,17 @@ export function createOrUpdateTransactionTypeUserStat(event: ethereum.Event, tra
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
-
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.transactionType = transactionType;
     stat.userId = userId;
 
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }
 
@@ -94,8 +103,9 @@ export function createOrUpdateTransactionTypeUserAppStat(event: ethereum.Event, 
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
-
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.transactionType = transactionType;
     stat.userId = userId;
     stat.appId = appId;
@@ -103,7 +113,8 @@ export function createOrUpdateTransactionTypeUserAppStat(event: ethereum.Event, 
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }
 
@@ -117,14 +128,16 @@ export function createOrUpdateTransactionAppStat(event: ethereum.Event, appAddre
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
-
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.appId = appId;
 
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }
 
@@ -138,14 +151,16 @@ export function createOrUpdateTransactionUserStat(event: ethereum.Event): void {
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
-
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.userId = userId;
 
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }
 
@@ -160,14 +175,16 @@ export function createOrUpdateTransactionUserAppStat(event: ethereum.Event, appA
         stat.createdAtBlock = event.block.number;
         stat.totalCount = 0;
         stat.totalGasUsed = BigInt.fromI32(0);
+        stat.totalGasCost = BigInt.fromI32(0);
     }
-
+    const gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
     stat.userId = userId;
     stat.appId = appId;
 
     stat.updatedAt = event.block.timestamp;
     stat.updatedAtBlock = event.block.number;
     stat.totalCount = stat.totalCount + 1;
-    stat.totalGasUsed = stat.totalGasUsed.plus(event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0));
+    stat.totalGasUsed = stat.totalGasUsed.plus(gasUsed);
+    stat.totalGasCost = stat.totalGasCost.plus(event.transaction.gasPrice.times(gasUsed));
     stat.save();
 }

--- a/src/helpers/loadOrCreate.ts
+++ b/src/helpers/loadOrCreate.ts
@@ -18,6 +18,7 @@ export function createTransaction(event: ethereum.Event, eventType: string, appA
     transaction.userId = user.id;
     transaction.appId = appAddress.toHex();
     transaction.gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+    transaction.gasPrice = event.transaction.gasPrice;
     transaction.createdAt = event.block.timestamp;
     transaction.createdAtBlock = event.block.number;
     transaction.transactionType = transactionType;


### PR DESCRIPTION

## Summary

This PR adds new attribute `totalGasCosts` to Transaction Stats and attribute `gasPrice` to Transaction Entity.

## Description

New attribute  `totalGasCosts` in Transaction Stats accumulates the result of `gasUsed * transaction.gasPrice` for each transaction. This will allow better calculations of transactions actual costs.

 New attribute `gasPrice` in Transaction is just gas price in the blockchain transaction.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
