### PR TITLE
feat: create timestamp entity every hour

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4,6 +4,13 @@ type User @entity(immutable: true) {
   createdAtBlock: BigInt!
 }
 
+type Timestamp @entity(immutable: true) {
+  # timestamp on the hour in UTC seconds
+  id: ID!
+  # the first block number of that hour
+  blockNumber: BigInt!
+}
+
 type Transaction @entity(immutable: true) {
   id: ID!
   transactionType: String!

--- a/src/AppFactory.ts
+++ b/src/AppFactory.ts
@@ -1,8 +1,9 @@
-import { DataSourceContext } from "@graphprotocol/graph-ts";
+import { DataSourceContext, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Created } from "../generated/AppFactory/AppFactory";
 import { ERC20FactoryFacet, ERC721FactoryFacet, RewardsFacet } from "../generated/templates";
-import { createTransaction } from "./helpers";
+import { createTransaction, secondsInHour } from "./helpers";
 import { APP_CREATE_TYPE } from "./helpers/transactions";
+import { Timestamp } from "../generated/schema";
 
 export function handleCreated(event: Created): void {
   let context = new DataSourceContext();
@@ -13,4 +14,16 @@ export function handleCreated(event: Created): void {
   RewardsFacet.createWithContext(event.params.id, context);
 
   createTransaction(event, APP_CREATE_TYPE, event.params.id);
+}
+
+export function handleBlock(block: ethereum.Block): void {
+  // floor timestamp to previous hour
+  let hourTimestamp = block.timestamp.div(secondsInHour).times(secondsInHour);
+
+  let exists = Timestamp.load(hourTimestamp.toString());
+  if(!exists){
+    let timestamp = new Timestamp(hourTimestamp.toString());
+    timestamp.blockNumber = block.number;
+    timestamp.save();
+  }
 }

--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -2,3 +2,5 @@ import {BigInt} from "@graphprotocol/graph-ts";
 
 export const One = BigInt.fromI32(1);
 export const Zero = BigInt.fromI32(0);
+
+export const secondsInHour = BigInt.fromI32(3600);

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -29,6 +29,8 @@ dataSources:
         - event: Created(address,address,string)
           handler: handleCreated
           receipt: true
+      blockHandlers:
+        - handler: handleBlock
       file: ./src/AppFactory.ts
 templates:
   - name: ERC721FactoryFacet


### PR DESCRIPTION
A rough implementation that would create a timestamp entity every hour that contains the first block number of that hour.

**Things to consider:**
- It requires indexing every block which may impact indexing speed
- It will add `8766` entities a year (hours in year)

Would be used to get a range of block numbers given a list Unix timestamps on each hour in UTC
```graphql
{
  timestamps (where : {id_in: [
      "1728406800",
      "1728410400",
      "1728414000"
  ] }){
    blockNumber
  }
}
```